### PR TITLE
Core queries

### DIFF
--- a/probability.sql
+++ b/probability.sql
@@ -69,7 +69,7 @@ stu_crop_suit_max AS (
 	FROM refgrid_stu_suit
 	GROUP BY objectid, cropgroup_no, smu, stu, pcarea
 	ORDER BY objectid, cropgroup_no, pcarea DESC
-)
+),
 
 -- After the crop group, we merge the crop id based on the table crop_to_crop_group.
 


### PR DESCRIPTION
Changed query so that not only crop groups of the stu with max pcarea are considered, but all crop groups.
If stu with max pcarea is not suitable for all crop groups, missing groups are taken from the next biggest stu containing the missing group.
